### PR TITLE
adding authorDate and commitDate to the object stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ Commit object properties:
 * `author`: an object representing the author of the commit
   - `name`: the name of the committer
   - `email`: the email of the committer
+* `authorDate`: a string representing the date of the original commit by the author (never change)
+* `commitDate`: a string representing the date of the last change of the commit
 * `summary`: the one-line summary of the commit
 * `description`: the free-form text content of the summary, minus specific metadata lines
 * `reviewers`: an array containing objects with `name` and `email` properties if the commit metadata contains reviewers in a `Reviewed-By: Foo Bar <baz@boom>` format.

--- a/commit-stream.js
+++ b/commit-stream.js
@@ -23,10 +23,22 @@ function commitStream (ghUser, ghProject) {
       commit = {
         sha: line.split(' ')[1]
       }
+    } else if (m = line.match(/^CommitDate: (.*)$/)) {
+      if (!commit)
+        throw new Error('wut?')
+      commit.commitDate = m[1].trim()
     } else if (m = line.match(/^Author: ([^<]+) <([^>]+)>$/)) {
       if (!commit)
         throw new Error('wut?')
       commit.author = { name: m[1], email: m[2] }
+    } else if (m = line.match(/^AuthorDate: (.*)$/)) {
+      if (!commit)
+        throw new Error('wut?')
+      commit.authorDate = m[1].trim()
+    } else if (m = line.match(/^Date: (.*)$/)) {
+      if (!commit)
+        throw new Error('wut?')
+      commit.authorDate = m[1].trim()
     } else if (m = line.match(/^\s+Reviewed[- ]?By:?\s*([^<]+) <([^>]+)>\s*$/i)) {
       if (!commit.reviewers)
         commit.reviewers = []

--- a/test.js
+++ b/test.js
@@ -20,6 +20,7 @@ test('current plain commit log', function (t) {
 
     t.deepEqual(list[list.length - 9], {
         author      : { email: 'ralphtheninja@riseup.net', name: 'Lars-Magnus Skog' }
+      , authorDate  : 'Tue Feb 9 15:46:46 2016 +0100'
       , description : [
             'Fixes: https://github.com/rvagg/changelog-maker/issues/35'
         ]
@@ -34,12 +35,14 @@ test('current plain commit log', function (t) {
 
     t.deepEqual(list[list.length - 4], {
         author: { email: 'rod@vagg.org', name: 'Rod Vagg' }
+      , authorDate: 'Fri Apr 17 11:16:51 2015 +1000'
       , sha: 'f92b93c3c7175b07f847dd45058b121cea6b3a20'
       , summary: 'deleted package.json line'
     }, 'got correct fourth commit')
 
     t.deepEqual(list[list.length - 3], {
         author: { email: 'rod@vagg.org', name: 'Rod Vagg' }
+      , authorDate: 'Fri Apr 17 11:13:06 2015 +1000'
       , description: [ 'comment', 'Reviewed-By: Nobody' ]
       , sha: 'db34ce2af09a6a9fb70241d43965a2bc48b90b4c'
       , summary: 'squished package.json'
@@ -47,6 +50,7 @@ test('current plain commit log', function (t) {
 
     t.deepEqual(list[list.length - 2], {
         author      : { email: 'rod@vagg.org', name: 'Rod Vagg' }
+      , authorDate: 'Fri Apr 17 10:52:16 2015 +1000'
       , description : [
             'Some extra summary information here'
           , 'newline'
@@ -63,6 +67,7 @@ test('current plain commit log', function (t) {
 
     t.deepEqual(list[list.length - 1], {
         sha    : 'd94841274e2979e7758413a0f48fa37560d0dde6'
+      , authorDate: 'Thu Apr 16 20:49:21 2015 +1000'
       , author : { name: 'Rod Vagg', email: 'rod@vagg.org' }
       , summary: 'make it so'
     }, 'got correct first commit')


### PR DESCRIPTION
Hello Rod, 

I've added the authorDate and commitDate to the object stream (http://stackoverflow.com/questions/11856983/why-git-authordate-is-different-from-commitdate) which are important informations about a commit.

The UT has been updated consequently.

GrG
