### PR TITLE
allow for trailing slash in PR-URL

### DIFF
--- a/commit-stream.js
+++ b/commit-stream.js
@@ -36,7 +36,7 @@ function commitStream (ghUser, ghProject) {
       if (ghUser && ghProject && (m = commit.prUrl.match(/^\s*#?(\d+)\s*$/))) {
         commit.prUrl = 'https://github.com/' + ghUser + '/' + ghProject + '/pull/' + m[1]
       }
-      if (m = commit.prUrl.match(/^(https?:\/\/.+\/([^\/]+)\/([^\/]+))\/\w+\/(\d+)$/i)) {
+      if (m = commit.prUrl.match(/^(https?:\/\/.+\/([^\/]+)\/([^\/]+))\/\w+\/(\d+)(\/)?$/i)) {
         commit.ghIssue   = +m[4]
         commit.ghUser    = m[2]
         commit.ghProject = m[3]


### PR DESCRIPTION
Current regular expression will not match URL that ends in a slash.